### PR TITLE
Upgrade babel version to 7.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "author": "Sagar Chamling <sgr.raee@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.26.3",
-    "babel-loader": "7",
-    "babel-preset-env": "^1.7.0",
+    "@babel/core": "7.6.4",
+    "babel-loader": "8.0.6",
+    "@babel/preset-env": "^7.2.0",
     "css-loader": "^3.2.0",
     "eslint": "^6.5.1",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",


### PR DESCRIPTION
Issue #14 

This PR:

- Upgrade babel version to version 7.6.4, alongside with its dependencies.